### PR TITLE
CMake Updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ if (TOOLCHAIN STREQUAL "armgcc")
 
     target_compile_definitions(playdate_sdk PUBLIC TARGET_PLAYDATE=1)
     target_compile_options(playdate_sdk PUBLIC -Wall -Wno-unknown-pragmas -Wdouble-promotion)
-    target_compile_options(playdate_sdk PUBLIC $<$<CONFIG:DEBUG>:-O2>)
+    target_compile_options(playdate_sdk PRIVATE $<$<CONFIG:DEBUG>:-O2>)
+    target_compile_options(playdate_sdk INTERFACE $<$<CONFIG:DEBUG>:-O0>)
     target_compile_options(playdate_sdk PUBLIC $<$<CONFIG:RELEASE>:-O3>)
 
     target_compile_options(playdate_sdk PUBLIC ${MCFLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ project("PlaydateCPP")
 
 set(ENVSDK $ENV{PLAYDATE_SDK_PATH})
 file(TO_CMAKE_PATH ${ENVSDK} SDK)
+set(SDK ${SDK} PARENT_SCOPE)
 message(STATUS "Playdate SDK Path: " ${SDK})
 set(PDC "${SDK}/bin/pdc" -sdkpath "${SDK}" CACHE FILEPATH "path to the Playdate Compiler")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 project("PlaydateCPP")
 
+option(PDCPP_STAGE_IN_BINARY_DIR "Use CMake binary dir (instead of source dir) to stage files" OFF)
+
 set(ENVSDK $ENV{PLAYDATE_SDK_PATH})
 file(TO_CMAKE_PATH ${ENVSDK} SDK)
 set(SDK ${SDK} PARENT_SCOPE)

--- a/cmake/AddPlaydateApplication.cmake
+++ b/cmake/AddPlaydateApplication.cmake
@@ -1,6 +1,12 @@
 function(add_playdate_application PLAYDATE_GAME_NAME)
     message(STATUS "Adding playdate application ${PLAYDATE_GAME_NAME}")
 
+    if (PDCPP_STAGE_IN_BINARY_DIR)
+      set(PDCPP_STAGING_DIR ${CMAKE_CURRENT_BINARY_DIR})
+    else ()
+      set(PDCPP_STAGING_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+    endif ()
+
     if (TOOLCHAIN STREQUAL "armgcc")
         add_executable(${PLAYDATE_GAME_NAME})
 
@@ -10,25 +16,25 @@ function(add_playdate_application PLAYDATE_GAME_NAME)
             TARGET ${PLAYDATE_GAME_NAME} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy
             ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_SUB_DIR}${PLAYDATE_GAME_NAME}.elf
-            ${CMAKE_CURRENT_SOURCE_DIR}/Source/pdex.elf
+            ${PDCPP_STAGING_DIR}/Source/pdex.elf
         )
 
         add_custom_command(
             TARGET ${PLAYDATE_GAME_NAME} POST_BUILD
             COMMAND ${CMAKE_STRIP} --strip-unneeded -R .comment -g
             ${PLAYDATE_GAME_NAME}.elf
-            -o ${CMAKE_CURRENT_SOURCE_DIR}/Source/pdex.elf
+            -o ${PDCPP_STAGING_DIR}/Source/pdex.elf
         )
 
         add_custom_command(
             TARGET ${PLAYDATE_GAME_NAME} POST_BUILD
             COMMAND ${PDC} Source ${PLAYDATE_GAME_NAME}.pdx
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            WORKING_DIRECTORY ${PDCPP_STAGING_DIR}
         )
 
         set_property(
             TARGET ${PLAYDATE_GAME_NAME} PROPERTY ADDITIONAL_CLEAN_FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/${PLAYDATE_GAME_NAME}.pdx
+            ${PDCPP_STAGING_DIR}/${PLAYDATE_GAME_NAME}.pdx
         )
 
     else ()
@@ -38,7 +44,7 @@ function(add_playdate_application PLAYDATE_GAME_NAME)
             if(${CMAKE_GENERATOR} MATCHES "Visual Studio*" )
                 set(BUILD_SUB_DIR $<CONFIG>/)
                 file(TO_NATIVE_PATH ${SDK}/bin/PlaydateSimulator.exe SIMPATH)
-                file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${PLAYDATE_GAME_NAME}.pdx SIMGAMEPATH)
+                file(TO_NATIVE_PATH ${PDCPP_STAGING_DIR}/${PLAYDATE_GAME_NAME}.pdx SIMGAMEPATH)
                 set_property(TARGET ${PLAYDATE_GAME_NAME} PROPERTY VS_DEBUGGER_COMMAND ${SIMPATH})
                 set_property(TARGET ${PLAYDATE_GAME_NAME} PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS "\"${SIMGAMEPATH}\"")
             endif()
@@ -47,17 +53,17 @@ function(add_playdate_application PLAYDATE_GAME_NAME)
                     TARGET ${PLAYDATE_GAME_NAME} POST_BUILD
                     COMMAND ${CMAKE_COMMAND} -E copy
                     ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_SUB_DIR}${PLAYDATE_GAME_NAME}.dll
-                    ${CMAKE_CURRENT_SOURCE_DIR}/Source/pdex.dll)
+                    ${PDCPP_STAGING_DIR}/Source/pdex.dll)
         elseif (MINGW)
             add_custom_command(
                     TARGET ${PLAYDATE_GAME_NAME} POST_BUILD
                     COMMAND ${CMAKE_COMMAND} -E copy
                     ${CMAKE_CURRENT_BINARY_DIR}/lib${PLAYDATE_GAME_NAME}.dll
-                    ${CMAKE_CURRENT_SOURCE_DIR}/Source/pdex.dll)
+                    ${PDCPP_STAGING_DIR}/Source/pdex.dll)
         elseif(APPLE)
             if(${CMAKE_GENERATOR} MATCHES "Xcode" )
                 set(BUILD_SUB_DIR $<CONFIG>/)
-                set_property(TARGET ${PLAYDATE_GAME_NAME} PROPERTY XCODE_SCHEME_ARGUMENTS \"${CMAKE_CURRENT_SOURCE_DIR}/${PLAYDATE_GAME_NAME}.pdx\")
+                set_property(TARGET ${PLAYDATE_GAME_NAME} PROPERTY XCODE_SCHEME_ARGUMENTS \"${PDCPP_STAGING_DIR}/${PLAYDATE_GAME_NAME}.pdx\")
                 set_property(TARGET ${PLAYDATE_GAME_NAME} PROPERTY XCODE_SCHEME_EXECUTABLE ${SDK}/bin/Playdate\ Simulator.app)
             endif()
 
@@ -65,27 +71,27 @@ function(add_playdate_application PLAYDATE_GAME_NAME)
                 TARGET ${PLAYDATE_GAME_NAME} POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy
                 ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_SUB_DIR}lib${PLAYDATE_GAME_NAME}.dylib
-                ${CMAKE_CURRENT_SOURCE_DIR}/Source/pdex.dylib)
+                ${PDCPP_STAGING_DIR}/Source/pdex.dylib)
 
         elseif(UNIX)
             add_custom_command(
                 TARGET ${PLAYDATE_GAME_NAME} POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy
                 ${CMAKE_CURRENT_BINARY_DIR}/lib${PLAYDATE_GAME_NAME}.so
-                ${CMAKE_CURRENT_SOURCE_DIR}/Source/pdex.so)
+                ${PDCPP_STAGING_DIR}/Source/pdex.so)
         else()
             message(FATAL_ERROR "Platform not supported!")
         endif()
 
         set_property(
             TARGET ${PLAYDATE_GAME_NAME} PROPERTY ADDITIONAL_CLEAN_FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/${PLAYDATE_GAME_NAME}.pdx
+            ${PDCPP_STAGING_DIR}/${PLAYDATE_GAME_NAME}.pdx
         )
 
         add_custom_command(
             TARGET ${PLAYDATE_GAME_NAME} POST_BUILD
-            COMMAND ${PDC} ${CMAKE_CURRENT_SOURCE_DIR}/Source
-            ${CMAKE_CURRENT_SOURCE_DIR}/${PLAYDATE_GAME_NAME}.pdx)
+            COMMAND ${PDC} ${PDCPP_STAGING_DIR}/Source
+            ${PDCPP_STAGING_DIR}/${PLAYDATE_GAME_NAME}.pdx)
     endif()
 
 

--- a/cmake/AddPlaydateApplication.cmake
+++ b/cmake/AddPlaydateApplication.cmake
@@ -94,7 +94,5 @@ function(add_playdate_application PLAYDATE_GAME_NAME)
             ${PDCPP_STAGING_DIR}/${PLAYDATE_GAME_NAME}.pdx)
     endif()
 
-
-    target_compile_options(${PLAYDATE_GAME_NAME} PUBLIC $<$<CONFIG:DEBUG>:-O0>)
-    target_compile_options(${PLAYDATE_GAME_NAME} PUBLIC $<$<CONFIG:RELEASE>:-O3>)
+    target_link_libraries(${PLAYDATE_GAME_NAME} PUBLIC pdcpp_core)
 endfunction()

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -16,8 +16,5 @@ set(CMAKE_XCODE_GENERATE_SCHEME TRUE)
 # Now we can declare our application
 add_playdate_application(HelloWorld)
 
-# Add its sources
+# Add its sources, and you're good to go!
 target_sources(HelloWorld PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
-
-# Link against the pdcpp_core library, and you're good to go!
-target_link_libraries(HelloWorld pdcpp_core)

--- a/examples/hello_world/main.cpp
+++ b/examples/hello_world/main.cpp
@@ -8,7 +8,6 @@
  */
 #include <memory>
 #include <string>
-#include <pd_api.h>
 #include <pdcpp/pdnewlib.h>
 
 

--- a/examples/particles/CMakeLists.txt
+++ b/examples/particles/CMakeLists.txt
@@ -60,8 +60,5 @@ set(CMAKE_XCODE_GENERATE_SCHEME TRUE)
 # Now we can declare our application
 add_playdate_application(Particles)
 
-# Add its sources
+# Add its sources, and you're good to go!
 target_sources(Particles PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
-
-# Link against the pdcpp_core library, and you're good to go!
-target_link_libraries(Particles pdcpp_core)

--- a/examples/particles/main.cpp
+++ b/examples/particles/main.cpp
@@ -11,7 +11,6 @@
 #include <vector>
 #include <memory>
 
-#include <pd_api.h>
 #include <pdcpp/pdnewlib.h>
 
 // First, give the library that will be included a name


### PR DESCRIPTION
These changes aim to make use of `playdate-cpp` easier:

1. Set the SDK variable in the `PARENT_SCOPE` so that projects using this library don't need to locate the SDK themselves.
2. Add the `PDCPP_STAGE_IN_BINARY_DIR` option to allow projects to stage files in the `CMAKE_CURRENT_BINARY_DIR` instead of the `CMAKE_CURRENT_SOURCE_DIR`. This follows the standard CMake practice of keeping generated content within the binary directory, with the expectation that any content that a developer wants packaged (e.g. a `pdxinfo` file) be copied in via calls to `configure_file()`. Since this is different behavior from the Playdate SDK, the option is off by default.
3. Update `add_playdate_application()` to automatically link against `pdcpp_core`, which guarantees the application will inherit the optimization flags specified for `playdate_sdk`, and avoids passing multiple sets of optimization flags to the compiler.

Please let me know if you have any questions!